### PR TITLE
Remove tmp folder so it is not deployed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
         cd ${{ inputs.deta-project-dir }}
         ~/.deta/bin/deta clone --name ${{ inputs.deta-name }} --project ${{ inputs.deta-project }} tmp/
         cp -r tmp/.deta .
+        rm -r tmp/
 
     # Using the access token, deploy the project to Deta
     # https://docs.deta.sh/docs/cli/commands#deta-deploy


### PR DESCRIPTION
When deploying the app, the tmp folder is included. Instead that should be removed